### PR TITLE
📝 docs(config): require user-provided certificate file

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -92,7 +92,7 @@ api_keys:
   - key: "your-api-key-here"
 asksage_server_base_url: "https://api.asksage.anl.gov/server"
 asksage_user_base_url: "https://api.asksage.anl.gov/user"
-cert_path: "./anl_provided/asksage_anl_gov.pem"
+cert_path: "/path/to/your/asksage_anl_gov.pem"
 timeout_seconds: 30.0
 ```
 
@@ -114,7 +114,7 @@ api_keys:
     name: "backup"
 asksage_server_base_url: "https://api.asksage.anl.gov/server"
 asksage_user_base_url: "https://api.asksage.anl.gov/user"
-cert_path: "./anl_provided/asksage_anl_gov.pem"
+cert_path: "/path/to/your/asksage_anl_gov.pem"
 timeout_seconds: 30.0
 ```
 
@@ -149,7 +149,7 @@ When running without an existing config file:
 2. Automatically selects a random available port (can be overridden)
 3. Prompts for:
    - Multiple AskSage API keys with priority weights (supports lab key pooling)
-   - Certificate file path (defaults to bundled certificate, supports relative paths like `./cert.pem` or `~/cert.pem`)
+   - Certificate file path (you must provide your own certificate file, supports relative paths like `./cert.pem` or `~/cert.pem`)
    - Verbose mode preference
 4. Validates connectivity to configured URLs
 5. Shows the generated config in a formatted display for review before proceeding
@@ -178,7 +178,7 @@ Enter priority weight (default: 1.0): 1.0
 Enter optional name for this API key (default: key_2): backup
 Add another API key? [y/N]: n
 
-Enter certificate path: ./anl_provided/asksage_anl_gov.pem
+Enter certificate path: /path/to/your/asksage_anl_gov.pem
 Enable verbose mode? [Y/n]
 Created new configuration at: /home/your_username/.config/asksage_proxy/config.yaml
 Configured 2 API key(s) with load balancing
@@ -196,7 +196,7 @@ Configured 2 API key(s) with load balancing
 | `api_key`                 | Legacy single API key (deprecated, use `api_keys` instead)                        | (Backward compatibility only)        |
 | `asksage_server_base_url` | AskSage Server API base URL                                                       | `https://api.asksage.anl.gov/server` |
 | `asksage_user_base_url`   | AskSage User API base URL                                                         | `https://api.asksage.anl.gov/user`   |
-| `cert_path`               | Path to SSL certificate file (relative paths automatically converted to absolute) | `./anl_provided/asksage_anl_gov.pem` |
+| `cert_path`               | Path to SSL certificate file (relative paths automatically converted to absolute) | (Required - no default)              |
 | `timeout_seconds`         | Request timeout in seconds                                                        | `30.0`                               |
 
 #### API Keys Configuration

--- a/examples/config_minimal.yaml
+++ b/examples/config_minimal.yaml
@@ -14,5 +14,8 @@ api_keys:
 asksage_server_base_url: "https://api.asksage.anl.gov/server"
 asksage_user_base_url: "https://api.asksage.anl.gov/user"
 
+# Certificate path (required - provide your own certificate file)
+cert_path: "/path/to/your/asksage_anl_gov.pem"
+
 # Timeout settings
 timeout_seconds: 30.0

--- a/examples/config_multiple_keys.yaml
+++ b/examples/config_multiple_keys.yaml
@@ -22,8 +22,8 @@ api_keys:
 asksage_server_base_url: "https://api.asksage.anl.gov/server"
 asksage_user_base_url: "https://api.asksage.anl.gov/user"
 
-# Certificate path (optional)
-cert_path: "./anl_provided/asksage_anl_gov.pem"
+# Certificate path (required - provide your own certificate file)
+cert_path: "/path/to/your/asksage_anl_gov.pem"
 
 # Timeout settings
 timeout_seconds: 30.0

--- a/examples/config_simple_keys.yaml
+++ b/examples/config_simple_keys.yaml
@@ -19,5 +19,8 @@ api_keys:
 asksage_server_base_url: "https://api.asksage.anl.gov/server"
 asksage_user_base_url: "https://api.asksage.anl.gov/user"
 
+# Certificate path (required - provide your own certificate file)
+cert_path: "/path/to/your/asksage_anl_gov.pem"
+
 # Timeout settings
 timeout_seconds: 30.0

--- a/src/asksage_proxy/client.py
+++ b/src/asksage_proxy/client.py
@@ -1,7 +1,6 @@
 """AskSage API client for proxy operations."""
 
 import os
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 import aiohttp
@@ -31,21 +30,16 @@ class AskSageClient:
 
         ssl_context = ssl.create_default_context()
 
-        # Use the ANL provided certificate
+        # Use the configured certificate path
         cert_path = self.config.cert_path
-        if not cert_path:
-            # Default to the ANL provided certificate
-            cert_path = str(
-                Path(__file__).parent.parent.parent
-                / "anl_provided"
-                / "asksage_anl_gov.pem"
-            )
 
         if cert_path and os.path.exists(cert_path):
             ssl_context.load_verify_locations(cert_path)
             logger.info(f"Using certificate: {cert_path}")
         else:
-            logger.warning("No certificate found, using default SSL context")
+            if cert_path:
+                logger.warning(f"Certificate file not found: {cert_path}")
+            logger.warning("No valid certificate found, using default SSL context")
 
         self._session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=self.config.timeout_seconds),


### PR DESCRIPTION
- update README and config examples to clarify certificate requirement
- remove examples referencing bundled certificate path
- add notes about required certificate in config samples
- document certificate prompt in interactive setup

♻️ refactor(client): remove default certificate fallback

- require explicit user-provided certificate path in client config
- remove fallback to bundled certificate
- update warnings for missing or invalid certificate file